### PR TITLE
Make sure that the camera tracks the player in both directions.

### DIFF
--- a/mario-10-exercise/Map.lua
+++ b/mario-10-exercise/Map.lua
@@ -208,8 +208,9 @@ function Map:update(dt)
 
     -- keep camera's X coordinate following the player, preventing camera from
     -- scrolling past 0 to the left and the map's width
-    self.camX = math.max(0, math.min(self.player.x - virtualWidth / 2,
-        math.min(self.mapWidthPixels - virtualWidth, self.player.x)))
+    -- and also showing the _full_ map.
+    self.camX = math.max(0, math.min(16 * self.mapWidth - VIRTUAL_WIDTH,
+                    self.player.x - (VIRTUAL_WIDTH / 2 )))
 end
 
 -- gets the tile type at a given pixel coordinate

--- a/mario-10/Map.lua
+++ b/mario-10/Map.lua
@@ -211,8 +211,9 @@ function Map:update(dt)
 
     -- keep camera's X coordinate following the player, preventing camera from
     -- scrolling past 0 to the left and the map's width
-    self.camX = math.max(0, math.min(self.player.x - virtualWidth / 2,
-        math.min(self.mapWidthPixels - virtualWidth, self.player.x)))
+    -- and also showing the _full_ map.
+    self.camX = math.max(0, math.min(16 * self.mapWidth - VIRTUAL_WIDTH,
+                    self.player.x - (VIRTUAL_WIDTH / 2 )))
 end
 
 -- gets the tile type at a given pixel coordinate

--- a/mario-11-exercise/Map.lua
+++ b/mario-11-exercise/Map.lua
@@ -216,8 +216,9 @@ function Map:update(dt)
 
     -- keep camera's X coordinate following the player, preventing camera from
     -- scrolling past 0 to the left and the map's width
-    self.camX = math.max(0, math.min(self.player.x - virtualWidth / 2,
-        math.min(self.mapWidthPixels - virtualWidth, self.player.x)))
+    -- and also showing the _full_ map.
+    self.camX = math.max(0, math.min(16 * self.mapWidth - VIRTUAL_WIDTH,
+                    self.player.x - (VIRTUAL_WIDTH / 2 )))
 end
 
 -- gets the tile type at a given pixel coordinate

--- a/mario-11/Map.lua
+++ b/mario-11/Map.lua
@@ -216,8 +216,9 @@ function Map:update(dt)
 
     -- keep camera's X coordinate following the player, preventing camera from
     -- scrolling past 0 to the left and the map's width
-    self.camX = math.max(0, math.min(self.player.x - virtualWidth / 2,
-        math.min(self.mapWidthPixels - virtualWidth, self.player.x)))
+    -- and also showing the _full_ map.
+    self.camX = math.max(0, math.min(16 * self.mapWidth - VIRTUAL_WIDTH,
+                    self.player.x - (VIRTUAL_WIDTH / 2 )))
 end
 
 -- gets the tile type at a given pixel coordinate

--- a/mario-5/Map.lua
+++ b/mario-5/Map.lua
@@ -180,8 +180,9 @@ function Map:update(dt)
 
     -- keep camera's X coordinate following the player, preventing camera from
     -- scrolling past 0 to the left and the map's width
-    self.camX = math.max(0, math.min(self.player.x - virtualWidth / 2,
-        math.min(self.mapWidthPixels - virtualWidth, self.player.x)))
+    -- and also showing the _full_ map.
+    self.camX = math.max(0, math.min(16 * self.mapWidth - VIRTUAL_WIDTH,
+                    self.player.x - (VIRTUAL_WIDTH / 2 )))
 end
 
 -- returns an integer value for the tile at a given x-y coordinate

--- a/mario-6-exercise/Map.lua
+++ b/mario-6-exercise/Map.lua
@@ -180,8 +180,9 @@ function Map:update(dt)
 
     -- keep camera's X coordinate following the player, preventing camera from
     -- scrolling past 0 to the left and the map's width
-    self.camX = math.max(0, math.min(self.player.x - virtualWidth / 2,
-        math.min(self.mapWidthPixels - virtualWidth, self.player.x)))
+    -- and also showing the _full_ map.
+    self.camX = math.max(0, math.min(16 * self.mapWidth - VIRTUAL_WIDTH,
+                    self.player.x - (VIRTUAL_WIDTH / 2 )))
 end
 
 -- returns an integer value for the tile at a given x-y coordinate

--- a/mario-6/Map.lua
+++ b/mario-6/Map.lua
@@ -180,8 +180,9 @@ function Map:update(dt)
 
     -- keep camera's X coordinate following the player, preventing camera from
     -- scrolling past 0 to the left and the map's width
-    self.camX = math.max(0, math.min(self.player.x - virtualWidth / 2,
-        math.min(self.mapWidthPixels - virtualWidth, self.player.x)))
+    -- and also showing the _full_ map.
+    self.camX = math.max(0, math.min(16 * self.mapWidth - VIRTUAL_WIDTH,
+                    self.player.x - (VIRTUAL_WIDTH / 2 )))
 end
 
 -- returns an integer value for the tile at a given x-y coordinate


### PR DESCRIPTION
The current code doesn't keep the playfield visible with the player. If the player moves towards the end of the level the camera stops and doesn't show them all the way to the edge. This merge request _only_ makes sure that the entire playfield is shown not that the player is confined to the map's tiles.

All files that have the "final" version of the camera from the exercises have been updated to use the corrected camera.