### PR TITLE
Camera Tracks Player && Player stays within playfield.

### DIFF
--- a/mario-10-exercise/Map.lua
+++ b/mario-10-exercise/Map.lua
@@ -205,7 +205,14 @@ end
 -- function to update camera offset based on player coordinates
 function Map:update(dt)
     self.player:update(dt)
-
+    
+	-- keep the player within the X playfield.
+    if self.player.x <= 0 then
+        self.player.x = 0
+    elseif self.player.x > 16 * self.mapWidth - self.player.width then
+        self.player.x = 16 * self.mapWidth - self.player.width
+    end
+    
     -- keep camera's X coordinate following the player, preventing camera from
     -- scrolling past 0 to the left and the map's width
     -- and also showing the _full_ map.

--- a/mario-10-exercise/Map.lua
+++ b/mario-10-exercise/Map.lua
@@ -208,8 +208,9 @@ function Map:update(dt)
 
     -- keep camera's X coordinate following the player, preventing camera from
     -- scrolling past 0 to the left and the map's width
-    self.camX = math.max(0, math.min(self.player.x - virtualWidth / 2,
-        math.min(self.mapWidthPixels - virtualWidth, self.player.x)))
+    -- and also showing the _full_ map.
+    self.camX = math.max(0, math.min(16 * self.mapWidth - VIRTUAL_WIDTH,
+                    self.player.x - (VIRTUAL_WIDTH / 2 )))
 end
 
 -- gets the tile type at a given pixel coordinate

--- a/mario-10/Map.lua
+++ b/mario-10/Map.lua
@@ -209,6 +209,13 @@ end
 function Map:update(dt)
     self.player:update(dt)
 
+	-- keep the player within the X playfield.
+    if self.player.x <= 0 then
+        self.player.x = 0
+    elseif self.player.x > 16 * self.mapWidth - self.player.width then
+        self.player.x = 16 * self.mapWidth - self.player.width
+    end
+    
     -- keep camera's X coordinate following the player, preventing camera from
     -- scrolling past 0 to the left and the map's width
     -- and also showing the _full_ map.

--- a/mario-10/Map.lua
+++ b/mario-10/Map.lua
@@ -211,8 +211,9 @@ function Map:update(dt)
 
     -- keep camera's X coordinate following the player, preventing camera from
     -- scrolling past 0 to the left and the map's width
-    self.camX = math.max(0, math.min(self.player.x - virtualWidth / 2,
-        math.min(self.mapWidthPixels - virtualWidth, self.player.x)))
+    -- and also showing the _full_ map.
+    self.camX = math.max(0, math.min(16 * self.mapWidth - VIRTUAL_WIDTH,
+                    self.player.x - (VIRTUAL_WIDTH / 2 )))
 end
 
 -- gets the tile type at a given pixel coordinate

--- a/mario-11-exercise/Map.lua
+++ b/mario-11-exercise/Map.lua
@@ -213,7 +213,14 @@ end
 -- function to update camera offset based on player coordinates
 function Map:update(dt)
     self.player:update(dt)
-
+    
+	-- keep the player within the X playfield.
+    if self.player.x <= 0 then
+        self.player.x = 0
+    elseif self.player.x > 16 * self.mapWidth - self.player.width then
+        self.player.x = 16 * self.mapWidth - self.player.width
+    end
+    
     -- keep camera's X coordinate following the player, preventing camera from
     -- scrolling past 0 to the left and the map's width
     -- and also showing the _full_ map.

--- a/mario-11-exercise/Map.lua
+++ b/mario-11-exercise/Map.lua
@@ -216,8 +216,9 @@ function Map:update(dt)
 
     -- keep camera's X coordinate following the player, preventing camera from
     -- scrolling past 0 to the left and the map's width
-    self.camX = math.max(0, math.min(self.player.x - virtualWidth / 2,
-        math.min(self.mapWidthPixels - virtualWidth, self.player.x)))
+    -- and also showing the _full_ map.
+    self.camX = math.max(0, math.min(16 * self.mapWidth - VIRTUAL_WIDTH,
+                    self.player.x - (VIRTUAL_WIDTH / 2 )))
 end
 
 -- gets the tile type at a given pixel coordinate

--- a/mario-11/Map.lua
+++ b/mario-11/Map.lua
@@ -213,7 +213,14 @@ end
 -- function to update camera offset based on player coordinates
 function Map:update(dt)
     self.player:update(dt)
-
+    
+	-- keep the player within the X playfield.
+    if self.player.x <= 0 then
+        self.player.x = 0
+    elseif self.player.x > 16 * self.mapWidth - self.player.width then
+        self.player.x = 16 * self.mapWidth - self.player.width
+    end
+    
     -- keep camera's X coordinate following the player, preventing camera from
     -- scrolling past 0 to the left and the map's width
     -- and also showing the _full_ map.

--- a/mario-11/Map.lua
+++ b/mario-11/Map.lua
@@ -216,8 +216,9 @@ function Map:update(dt)
 
     -- keep camera's X coordinate following the player, preventing camera from
     -- scrolling past 0 to the left and the map's width
-    self.camX = math.max(0, math.min(self.player.x - virtualWidth / 2,
-        math.min(self.mapWidthPixels - virtualWidth, self.player.x)))
+    -- and also showing the _full_ map.
+    self.camX = math.max(0, math.min(16 * self.mapWidth - VIRTUAL_WIDTH,
+                    self.player.x - (VIRTUAL_WIDTH / 2 )))
 end
 
 -- gets the tile type at a given pixel coordinate

--- a/mario-5/Map.lua
+++ b/mario-5/Map.lua
@@ -177,7 +177,14 @@ end
 -- function to update camera offset based on player coordinates
 function Map:update(dt)
     self.player:update(dt)
-
+    
+	-- keep the player within the X playfield.
+    if self.player.x <= 0 then
+        self.player.x = 0
+    elseif self.player.x > 16 * self.mapWidth - self.player.width then
+        self.player.x = 16 * self.mapWidth - self.player.width
+    end
+    
     -- keep camera's X coordinate following the player, preventing camera from
     -- scrolling past 0 to the left and the map's width
     -- and also showing the _full_ map.

--- a/mario-5/Map.lua
+++ b/mario-5/Map.lua
@@ -180,8 +180,9 @@ function Map:update(dt)
 
     -- keep camera's X coordinate following the player, preventing camera from
     -- scrolling past 0 to the left and the map's width
-    self.camX = math.max(0, math.min(self.player.x - virtualWidth / 2,
-        math.min(self.mapWidthPixels - virtualWidth, self.player.x)))
+    -- and also showing the _full_ map.
+    self.camX = math.max(0, math.min(16 * self.mapWidth - VIRTUAL_WIDTH,
+                    self.player.x - (VIRTUAL_WIDTH / 2 )))
 end
 
 -- returns an integer value for the tile at a given x-y coordinate

--- a/mario-6-exercise/Map.lua
+++ b/mario-6-exercise/Map.lua
@@ -177,7 +177,14 @@ end
 -- function to update camera offset based on player coordinates
 function Map:update(dt)
     self.player:update(dt)
-
+    
+	-- keep the player within the X playfield.
+    if self.player.x <= 0 then
+        self.player.x = 0
+    elseif self.player.x > 16 * self.mapWidth - self.player.width then
+        self.player.x = 16 * self.mapWidth - self.player.width
+    end
+    
     -- keep camera's X coordinate following the player, preventing camera from
     -- scrolling past 0 to the left and the map's width
     -- and also showing the _full_ map.

--- a/mario-6-exercise/Map.lua
+++ b/mario-6-exercise/Map.lua
@@ -180,8 +180,9 @@ function Map:update(dt)
 
     -- keep camera's X coordinate following the player, preventing camera from
     -- scrolling past 0 to the left and the map's width
-    self.camX = math.max(0, math.min(self.player.x - virtualWidth / 2,
-        math.min(self.mapWidthPixels - virtualWidth, self.player.x)))
+    -- and also showing the _full_ map.
+    self.camX = math.max(0, math.min(16 * self.mapWidth - VIRTUAL_WIDTH,
+                    self.player.x - (VIRTUAL_WIDTH / 2 )))
 end
 
 -- returns an integer value for the tile at a given x-y coordinate

--- a/mario-6/Map.lua
+++ b/mario-6/Map.lua
@@ -177,7 +177,14 @@ end
 -- function to update camera offset based on player coordinates
 function Map:update(dt)
     self.player:update(dt)
-
+    
+	-- keep the player within the X playfield.
+    if self.player.x <= 0 then
+        self.player.x = 0
+    elseif self.player.x > 16 * self.mapWidth - self.player.width then
+        self.player.x = 16 * self.mapWidth - self.player.width
+    end
+    
     -- keep camera's X coordinate following the player, preventing camera from
     -- scrolling past 0 to the left and the map's width
     -- and also showing the _full_ map.

--- a/mario-6/Map.lua
+++ b/mario-6/Map.lua
@@ -180,8 +180,9 @@ function Map:update(dt)
 
     -- keep camera's X coordinate following the player, preventing camera from
     -- scrolling past 0 to the left and the map's width
-    self.camX = math.max(0, math.min(self.player.x - virtualWidth / 2,
-        math.min(self.mapWidthPixels - virtualWidth, self.player.x)))
+    -- and also showing the _full_ map.
+    self.camX = math.max(0, math.min(16 * self.mapWidth - VIRTUAL_WIDTH,
+                    self.player.x - (VIRTUAL_WIDTH / 2 )))
 end
 
 -- returns an integer value for the tile at a given x-y coordinate

--- a/mario-7-exercise/Map.lua
+++ b/mario-7-exercise/Map.lua
@@ -177,7 +177,14 @@ end
 -- function to update camera offset based on player coordinates
 function Map:update(dt)
     self.player:update(dt)
-
+    
+	-- keep the player within the X playfield.
+    if self.player.x <= 0 then
+        self.player.x = 0
+    elseif self.player.x > 16 * self.mapWidth - self.player.width then
+        self.player.x = 16 * self.mapWidth - self.player.width
+    end
+    
     -- keep camera's X coordinate following the player, preventing camera from
     -- scrolling past 0 to the left and the map's width
     self.camX = math.max(0, math.min(self.player.x - virtualWidth / 2,

--- a/mario-7/Map.lua
+++ b/mario-7/Map.lua
@@ -177,7 +177,14 @@ end
 -- function to update camera offset based on player coordinates
 function Map:update(dt)
     self.player:update(dt)
-
+    
+	-- keep the player within the X playfield.
+    if self.player.x <= 0 then
+        self.player.x = 0
+    elseif self.player.x > 16 * self.mapWidth - self.player.width then
+        self.player.x = 16 * self.mapWidth - self.player.width
+    end
+    
     -- keep camera's X coordinate following the player, preventing camera from
     -- scrolling past 0 to the left and the map's width
     self.camX = math.max(0, math.min(self.player.x - virtualWidth / 2,

--- a/mario-8-exercise/Map.lua
+++ b/mario-8-exercise/Map.lua
@@ -180,7 +180,14 @@ end
 -- function to update camera offset based on player coordinates
 function Map:update(dt)
     self.player:update(dt)
-
+    
+	-- keep the player within the X playfield.
+    if self.player.x <= 0 then
+        self.player.x = 0
+    elseif self.player.x > 16 * self.mapWidth - self.player.width then
+        self.player.x = 16 * self.mapWidth - self.player.width
+    end
+    
     -- keep camera's X coordinate following the player, preventing camera from
     -- scrolling past 0 to the left and the map's width
     self.camX = math.max(0, math.min(self.player.x - virtualWidth / 2,

--- a/mario-8/Map.lua
+++ b/mario-8/Map.lua
@@ -180,7 +180,14 @@ end
 -- function to update camera offset based on player coordinates
 function Map:update(dt)
     self.player:update(dt)
-
+    
+	-- keep the player within the X playfield.
+    if self.player.x <= 0 then
+        self.player.x = 0
+    elseif self.player.x > 16 * self.mapWidth - self.player.width then
+        self.player.x = 16 * self.mapWidth - self.player.width
+    end
+    
     -- keep camera's X coordinate following the player, preventing camera from
     -- scrolling past 0 to the left and the map's width
     self.camX = math.max(0, math.min(self.player.x - virtualWidth / 2,


### PR DESCRIPTION
The current code doesn't keep the playfield visible with the player. If the player moves towards the end of the level the camera stops and doesn't show them all the way to the edge. This merge request makes sure that the entire playfield is shown and that the player stays within the X coordinates. 

All files that mention the map update with the "full" version of it have been updated accordingly. This way the code that a person who's trying to do the assignment with can actually do the assignment and actually spawn the flagpole at the end as is required by the assignment.